### PR TITLE
Formatting and light editing.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,39 +1,38 @@
-#Welcome! 
+# Welcome!
+Thank you for contributing to CDC's Open Source projects! If you have any
+questions or doubts, don't be afraid to send them our way. We appreciate all
+contributions, and we are looking forward to fostering an open, transparent, and
+collaborative environment.
 
-Thank you for contributing to CDC's Open Source projects! If you have any questions or doubts, 
-don't be afraid to send them our way. We appreciate all contributions, and we are looking forward 
-to fostering an open, transparent, and collaborative environment. 
-        
-Before contributing, we encourage you to also read or [LICENSE](https://github.com/CDCgov/template/blob/master/LICENSE), [README](https://github.com/CDCgov/template/blob/master/README.md), and [code-of-conduct](https://github.com/CDCgov/template/blob/master/code-of-conduct.md) files, 
-also found in this repository. If you have any inquiries or questions not answered by the content 
-of this repository, feel free to [contact us](mailto: chiic@cdc.gov). 
+Before contributing, we encourage you to also read or [LICENSE](https://github.com/CDCgov/template/blob/master/LICENSE),
+[README](https://github.com/CDCgov/template/blob/master/README.md), and
+[code-of-conduct](https://github.com/CDCgov/template/blob/master/code-of-conduct.md)
+files, also found in this repository. If you have any inquiries or questions not
+answered by the content of this repository, feel free to [contact us](mailto:chiic@cdc.gov).
 
+## Public Domain
+This project is in the public domain within the United States, and copyright and
+related rights in the work worldwide are waived through the [CC0 1.0 Universal public domain dedication](https://creativecommons.org/publicdomain/zero/1.0/).
+All contributions to this project will be released under the CC0 dedication. By
+submitting a pull request you are agreeing to comply with this waiver of
+copyright interest.
 
-##Public Domain: 
+## Requesting Changes
+Our pull request/merging process is designed to give the CDC Surveillance Team
+and other in our space an opportunity to consider and discuss any suggested
+changes. This policy affects all CDC spaces, both on-line and off, and all users
+are expected to abide by it.
 
-This project is in the public domain within the United States, and copyright and related rights in 
-the work worldwide are waived through the [CC0 1.0 Universal public domain dedication](https://creativecommons.org/publicdomain/zero/1.0/). All contributions 
-to this project will be released under the CC0 dedication. By submitting a pull request you are agreeing 
-to comply with this waiver of copyright interest. 
+### Open an issue in the repository
+If you don't have specific language to submit but would like to suggest a change
+or have something addressed, you can open an issue in this repository. Team
+members will respond to the issue as soon as possible.
 
-##Requesting Changes: 
-
-Our pull request/merging process is designed to give the CDC Surveillance Team and other in our space 
-an opportunity to consider and discuss any suggested changes. This policy affects all CDC spaces, both 
-online and off, and all users are expected to abide by it. 
-
-###Open an issue in the repository 
-                
-If you don't have specific language to submit but would like to suggest a change or have something 
-addressed, you can open an issue in this repository. Team members will respond to the issue as soon 
-as possible. 
-
-###Submit a pull request 
-               
-If you would like to contribute, please submit a pull request. In order for us to merge a pull 
-request, it must: 
-   * Be at least seven days old. Pull requests may be held longer if necessary to give people the opportunity to assess it. 
-   * Receive a +1 from a majority of team members associated with the request. If there is significant dissent between the team, 
-     a meeting will be held to discuss a plan of action for the pull request. 
-
-
+### Submit a pull request
+If you would like to contribute, please submit a pull request. In order for us
+to merge a pull request, it must:
+   * Be at least seven days old. Pull requests may be held longer if necessary
+     to give people the opportunity to assess it.
+   * Receive a +1 from a majority of team members associated with the request.
+     If there is significant dissent between the team, a meeting will be held to
+     discuss a plan of action for the pull request.

--- a/DISCLAIMER.md
+++ b/DISCLAIMER.md
@@ -1,11 +1,23 @@
-#DISCLAIMER 
+# DISCLAIMER
+Use of this service is limited only to **non-sensitive and publicly available
+data**. Users must not use, share, or store any kind of sensitive data like
+health status, provision or payment of healthcare, Personally Identifiable
+Information (PII) and/or Protected Health Information (PHI), etc. under **ANY**
+circumstance.
 
-Use of this service is limited only to **non-sensitive and publicly available data**. Users must not use, share, or store any kind
-of sensitive data like health status, provision or payment of healthcare, Personally Identifiable Information (PII) and/or 
-Protected Health Information (PHI), etc. under **ANY** circumstance. 
+Administrators for this service reserve the right to moderate all information
+used, shared, or stored with this service at any time. Any user that cannot
+abide by this disclaimer and Code of Conduct  may be subject to action, up to
+and including revoking access to services.
 
-Administrators for this service reserve the right to moderate all information used, shared, or stored with this service at any time.
-Any user that cannot abide by this disclaimer and Code of Conduct  may be subject to action, up to and including revoking access to 
-services. 
-
-The material embodied in this software is provided to you "as-is" and without warranty of any kind, express, implied or otherwise, including without limitation, any warranty of fitness for a particular purpose. In no event shall the Centers for Disease Control and Prevention (CDC) or the United States (U.S.) government be liable to you or anyone else for any direct, special, incidental, indirect or consequential damages of any kind, or any damages whatsoever, including without limitation, loss of profit, loss of use, savings or revenue, or the claims of third parties, whether or not CDC or the U.S. government has been advised of the possibility of such loss, however caused and on any theory of liability, arising out of or in connection with the possession, use or performance of this software.
+The material embodied in this software is provided to you "as-is" and without
+warranty of any kind, express, implied or otherwise, including without
+limitation, any warranty of fitness for a particular purpose. In no event shall
+the Centers for Disease Control and Prevention (CDC) or the United States (U.S.)
+government be liable to you or anyone else for any direct, special, incidental,
+indirect or consequential damages of any kind, or any damages whatsoever,
+including without limitation, loss of profit, loss of use, savings or revenue,
+or the claims of third parties, whether or not CDC or the U.S. government has
+been advised of the possibility of such loss, however caused and on any theory
+of liability, arising out of or in connection with the possession, use or
+performance of this software.

--- a/README.md
+++ b/README.md
@@ -1,38 +1,72 @@
 # Repository Template
-This Github organization was created for use by [CDC](http://www.cdc.gov) programs to collaborate on public health surveillance related projects in support of the [CDC Surveillance Strategy](http://www.cdc.gov/surveillance). This third party web application is not hosted by the CDC, but is used by CDC and its partners to share information and collaborate on software.
+This Github organization was created for use by [CDC](http://www.cdc.gov)
+programs to collaborate on public health surveillance related projects in
+support of the [CDC Surveillance Strategy](http://www.cdc.gov/surveillance).
+This third party web application is not hosted by the CDC, but is used by CDC
+and its partners to share information and collaborate on software.
 
-This repository serves as a template for other repositories to follow in order to provide the appropriate notices for users in regards to privacy protection, contribution, licensing, copyright, records management and collaboration.
+This repository serves as a template for other repositories to follow in order
+to provide the appropriate notices for users in regards to privacy protection,
+contribution, licensing, copyright, records management and collaboration.
 
-
-## Public Domain: 
-This project constitutes a work of the United States Government and is not subject to domestic copyright protection under 17 USC § 105. This project is in the public domain within the United States, and copyright and related rights in 
-the work worldwide are waived through the [CC0 1.0 Universal public domain dedication](https://creativecommons.org/publicdomain/zero/1.0/). All contributions 
-to this project will be released under the CC0 dedication. By submitting a pull request you are agreeing 
-to comply with this waiver of copyright interest. 
+## Public Domain
+This project constitutes a work of the United States Government and is not
+subject to domestic copyright protection under 17 USC § 105. This project is in
+the public domain within the United States, and copyright and related rights in
+the work worldwide are waived through the [CC0 1.0 Universal public domain dedication](https://creativecommons.org/publicdomain/zero/1.0/).
+All contributions to this project will be released under the CC0 dedication. By
+submitting a pull request you are agreeing to comply with this waiver of
+copyright interest.
 
 ## License
-The project utilizes code licensed under the terms of the Apache Software License and therefore is licensed under ASL v2 or later.
+The project utilizes code licensed under the terms of the Apache Software
+License and therefore is licensed under ASL v2 or later.
 
-This program is free software: you can redistribute it and/or modify it under the terms of the Apache Software License version 2, or (at your option) any later version.
+This program is free software: you can redistribute it and/or modify it under
+the terms of the Apache Software License version 2, or (at your option) any
+later version.
 
-This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the Apache Software License for more details.
+This program is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the Apache Software License for more details.
 
-You should have received a copy of the Apache Software License along with this program. If not, see http://www.apache.org/licenses/LICENSE-2.0.html
+You should have received a copy of the Apache Software License along with this
+program. If not, see http://www.apache.org/licenses/LICENSE-2.0.html
 
 ## Privacy
-This project contains only non-sensitive, publicly available data and information. All material and community participation is covered by the Surveillance Platform [Disclaimer](https://github.com/CDCgov/template/blob/master/DISCLAIMER.md) and [Code of Conduct](https://github.com/CDCgov/template/blob/master/code-of-conduct.md). For more information about CDC's privacy policy, please visit [http://www.cdc.gov/privacy.html](http://www.cdc.gov/privacy.html).
+This project contains only non-sensitive, publicly available data and
+information. All material and community participation is covered by the
+Surveillance Platform [Disclaimer](https://github.com/CDCgov/template/blob/master/DISCLAIMER.md)
+and [Code of Conduct](https://github.com/CDCgov/template/blob/master/code-of-conduct.md).
+For more information about CDC's privacy policy, please visit [http://www.cdc.gov/privacy.html](http://www.cdc.gov/privacy.html).
 
 ## Contributing
-Anyone is encouraged to contribute to the project by [forking](https://help.github.com/articles/fork-a-repo) and submitting a pull request. (If you are new to GitHub, you might start with a [basic tutorial](https://help.github.com/articles/set-up-git).) 
-By contributing to this project, you grant a world-wide, royalty-free, perpetual, irrevocable, non-exclusive, transferable license to all users under the terms of the [Apache Software License v2](http://www.apache.org/licenses/LICENSE-2.0.html) or later.
+Anyone is encouraged to contribute to the project by [forking](https://help.github.com/articles/fork-a-repo)
+and submitting a pull request. (If you are new to GitHub, you might start with a
+[basic tutorial](https://help.github.com/articles/set-up-git).) By contributing
+to this project, you grant a world-wide, royalty-free, perpetual, irrevocable,
+non-exclusive, transferable license to all users under the terms of the
+[Apache Software License v2](http://www.apache.org/licenses/LICENSE-2.0.html) or
+later.
 
-All comments, messages, pull requests, and other submissions received through CDC including this GitHub page are subject to the [Presidential Records Act](http://www.archives.gov/about/laws/presidential-records.html) and may be archived. Learn more at [http://www.cdc.gov/other/privacy.html](http://www.cdc.gov/other/privacy.html).
+All comments, messages, pull requests, and other submissions received through
+CDC including this GitHub page are subject to the [Presidential Records Act](http://www.archives.gov/about/laws/presidential-records.html)
+and may be archived. Learn more at [http://www.cdc.gov/other/privacy.html](http://www.cdc.gov/other/privacy.html).
 
 ## Records
-This project is not a source of government records, but is a copy to increase collaboration and collaborative potential. All government records will be published through the [CDC web site](http://www.cdc.gov.)
+This project is not a source of government records, but is a copy to increase
+collaboration and collaborative potential. All government records will be
+published through the [CDC web site](http://www.cdc.gov).
 
 ## Notices
-Please refer to [CDC's Template Repository](https://github.com/CDCgov/template) for more information about [contributing to this repository](https://github.com/CDCgov/template/blob/master/CONTRIBUTING.md), [public domain notices and disclaimers](https://github.com/CDCgov/template/blob/master/DISCLAIMER.md), and [code of conduct](https://github.com/CDCgov/template/blob/master/code-of-conduct.md).
+Please refer to [CDC's Template Repository](https://github.com/CDCgov/template)
+for more information about [contributing to this repository](https://github.com/CDCgov/template/blob/master/CONTRIBUTING.md),
+[public domain notices and disclaimers](https://github.com/CDCgov/template/blob/master/DISCLAIMER.md),
+and [code of conduct](https://github.com/CDCgov/template/blob/master/code-of-conduct.md).
 
 ## Hat-tips
-Thanks to [18F](https://18f.gsa.gov/)'s [open source policy](https://github.com/18F/open-source-policy) and [code of conduct](https://github.com/CDCgov/code-of-conduct/blob/master/code-of-conduct.md) that were very useful in setting up this GitHub organization. Thanks to CDC's [Informatics Innovation Unit](https://www.phiresearchlab.org/index.php/code-of-conduct/) that was helpful in modeling the code of conduct.
+Thanks to [18F](https://18f.gsa.gov/)'s [open source policy](https://github.com/18F/open-source-policy)
+and [code of conduct](https://github.com/CDCgov/code-of-conduct/blob/master/code-of-conduct.md)
+that were very useful in setting up this GitHub organization. Thanks to CDC's
+[Informatics Innovation Unit](https://www.phiresearchlab.org/index.php/code-of-conduct/)
+that was helpful in modeling the code of conduct.

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,89 +1,103 @@
-#Creating a Culture of Innovation 
+# Creating a Culture of Innovation
+We aspire to create a culture where people work joyfully, communicate openly
+about things that matter, and provide great services globally. We would like our
+team and communities (both government and private sector) to reflect on
+diversity of all kinds, not just the classes protected in law. Diversity fosters
+innovation. Diverse teams are creative teams. We need a diversity of perspective
+to create solutions for the challenges we face.
 
-We aspire to create a culture where people work joyfully, communicate openly about things that matter, and 
-provide great services globally. We would like our team and communities (both government and private sector)
-to reflect on diveristy of all kinds, not just the classes protected in law. Diversity fosters innovation. 
-Diverse teams are creative teams. We need a diversity of perpective to create solutions for the challenges
-we face. 
-    
-This is our code of conduct (adapted from [18F's Code of Conduct](https://github.com/18F/code-of-conduct)). 
-We follow all Equal Employment Opportunity laws and we expect everyone we work with to adhere to the [GSA Anti-harrasment Policy](http://www.gsa.gov/portal/directive/d0/content/512516), even if they do not work for the Centers for Disease Control 
-and Prevention or GSA. We expect every user to follow this code of conduct and the laws and policies mentioned above.
-    
-##Be Empowering 
-  
-Consider what you can do to encourage and support others. Make room for quieter voices to contribute. Offer support 
-and enthusiasm for great ideas. Leverage the low cost of experimentation to support your colleagues' ideas, and take 
-care to acknowledge the original source. Look for ways to contribute and collaborate, even in situations where you 
-normally wouldn't. Share your knowledge and skills. Prioritize access for and input from those who are traditionally 
-excluded from the civic process. 
+This is our code of conduct (adapted from [18F's Code of Conduct](https://github.com/18F/code-of-conduct)).
+We follow all Equal Employment Opportunity laws and we expect everyone we work
+with to adhere to the [GSA Anti-harrasment Policy](http://www.gsa.gov/portal/directive/d0/content/512516),
+even if they do not work for the Centers for Disease Control and Prevention or
+GSA. We expect every user to follow this code of conduct and the laws and
+policies mentioned above.
 
+## Be Empowering
+Consider what you can do to encourage and support others. Make room for quieter
+voices to contribute. Offer support and enthusiasm for great ideas. Leverage the
+low cost of experimentation to support your colleagues' ideas, and take care to
+acknowledge the original source. Look for ways to contribute and collaborate,
+even in situations where you normally wouldn't. Share your knowledge and skills.
+Prioritize access for and input from those who are traditionally excluded from
+the civic process.
 
-##Rules of Behavior
+## Rules of Behavior
+ * I understand that I must complete security awareness and records management
+   training annually in order to comply with the latest security and records
+   management policies.
+ * I understand that I must also follow the [Rules of Behavior for use of HHS Information Resources](http://www.hhs.gov/ocio/policy/hhs-rob.html)
+ * I understand that I must not use, share, or store any kind of sensitive data
+   (health status, provision or payment of healthcare, PII, etc.) under ANY
+   circumstance.
+ * I will not knowingly conceal, falsify, or remove information.
+ * I understand that I can only use non-sensitive and/or publicly available
+   data.
+ * I understand that all passwords I create to set up accounts need to comply
+   with CDC's password policy.
+ * I understand that the stewards reserves the right to moderate all data at any
+   time.
 
- * I understand that I must complete security awareness and records management training annually in order to comply with the 
-   latest security and records management policies. 
- * I understand that I must also follow the [Rules of Behavior for use of HHS Information Resources](http://www.hhs.gov/ocio/policy/hhs-rob.html) 
- * I understand that I must not use, share, or store any kind of sensitive data (health status, provision or payment 
-   of healthcare, PII, etc.) under ANY circumstance. 
- * I will not knowingly conceal, falsify, or remove information. 
- * I understand that I can only use non-sensitive and/or publicly available data. 
- * I understand that all passwords I create to set up accounts need to comply with CDC's password policy. 
- * I understand that the stewards reserves the right to moderate all data at any time. 
+## Boundaries
+Create boundaries to your own behavior and consider how you can create a safe
+space that helps prevent unacceptable behavior by others. We can't list all
+instances of unacceptable behavior, but we can provide examples to help guide
+our community in thinking through how to respond when we experience these types
+of behavior, whether directed at ourselves or others.
 
-##Boundaries 
+If you are unsure if something is appropriate behavior, it probably is not. Each
+person we interact with can define where the line is for them. Impact matters
+more than intent. Ensuring that your behavior does not have a negative impact is
+your responsibility. Problems usually arise when we assume that our way of
+thinking or behavior is the norm for everyone.
 
-Create boundaries to your own behavior and consider how you can create a safe space that helps prevent unacceptable
-behavior by others. We can't list all instances of unacceptable behavior, but we can provide examples to help guide 
-our community in thinking through how to respond when we experience these types of behavior, whether directed at 
-ourselves or others 
-
-If you are unsure if something is appropriate behavior, it probably is not. Each person we interact with can define
-where the line is for them. Impact matters more than intent. Ensuring that your behavior does not have a negative impact
-is your responsibility. Problems usually arise when we assume that our way of thinking or behavior is the norm for everyone. 
-    
-
-###Here are some examples of unacceptable behavior: 
- * Negative or offensive remarks based on the protected classes as listed in the GSA Anti-harrasment Policy of
-   race, religion, color, sex, national origin, age, disability, genetric information, sexual orientation, gender
-   identity, parental status, maritual status, and political affiliation as well as gender expression, mental 
-   illness, socioeconomic status or backgrounds, neuro(a)typicality, physical appearance, body size, or clothing. 
-   Consider that calling attention to differences can feel alienating. 
- * Sustained disruption of meetings, talks, or discussions, including chatrooms. 
+### Here are some examples of unacceptable behavior
+ * Negative or offensive remarks based on the protected classes as listed in the
+   GSA Anti-harrasment Policy of race, religion, color, sex, national origin,
+   age, disability, genetric information, sexual orientation, gender identity,
+   parental status, maritual status, and political affiliation as well as gender
+   expression, mental illness, socioeconomic status or backgrounds,
+   neuro(a)typicality, physical appearance, body size, or clothing. Consider
+   that calling attention to differences can feel alienating.
+ * Sustained disruption of meetings, talks, or discussions, including chatrooms.
  * Patronizing language or behavior.
- * Aggresive behavior, such as unconstructive criticism, providing correction that do not improve the conversation 
-   (sometimes referred to as "well actually's), repeatedly interrupting or talking over someone else, feigning 
-    surprise at someone's lack of knowledge or awareness about a topic, or subtle prejudice. 
- * Referring to people in a way that misidentifies their gender and/or rejects the validity of their gender 
-   identity; for instance by using incorrect pronouns or forms of address (misgendering) 
- * Retaliating against anyone who files a formal complaint that someone has violated these codes or laws. 
- 
-##Background 
-CDC Scientific Clearance is the process of obtaining approvals by appropriate CDC officials before a CDC information product
-is released to the public or CDC's external public health partners. Information products that require formal clearance include 
-print, electronic, or oral materials, that CDC employees author or co-author, whether published by CDC or outside CDC. 
-CDC contractors developing content on behalf of CDC for the public or CDC's external public health partners are also required
-to put their content through the formal clearance process. The collaborative functions related to the projects in the R&D lab include blogs, wikis, forums, bug tracking sites, source control and others deemed as necessary. 
+ * Aggresive behavior, such as unconstructive criticism, providing correction
+   that do not improve the conversation (sometimes referred to as "well
+   actually's"), repeatedly interrupting or talking over someone else, feigning
+   surprise at someone's lack of knowledge or awareness about a topic, or subtle
+   prejudice.
+ * Referring to people in a way that misidentifies their gender and/or rejects
+   the validity of their gender identity; for instance by using incorrect
+   pronouns or forms of address (misgendering).
+ * Retaliating against anyone who files a formal complaint that someone has
+   violated these codes or laws.
 
-For those individuals within the CDC, adherence to the following policies are required: 
-* CDC ["Clearance of Information Products Disseminated Outside CDC for Public Use"](http://www.cdc.gov/maso/Policy/PublicUse.pdf) 
-* [HHS "Ensuring the Quality of Information Disseminated by HHS agencies"](http://aspe.hhs.gov/infoquality) 
+## Background
+CDC Scientific Clearance is the process of obtaining approvals by appropriate
+CDC officials before a CDC information product is released to the public or
+CDC's external public health partners. Information products that require formal
+clearance include print, electronic, or oral materials, that CDC employees
+author or co-author, whether published by CDC or outside CDC. CDC contractors
+developing content on behalf of CDC for the public or CDC's external public
+health partners are also required to put their content through the formal
+clearance process. The collaborative functions related to the projects in the
+R&D lab include blogs, wikis, forums, bug tracking sites, source control and
+others deemed as necessary.
 
-All collaborativer materials will be controlled by the rules contained within this document. This will allow for the real-time collaboration opportunities among CDC employees, CDC contractors and CDC public health partners. 
+For those individuals within the CDC, adherence to the following policies are
+required:
+* CDC ["Clearance of Information Products Disseminated Outside CDC for Public Use"](http://www.cdc.gov/maso/Policy/PublicUse.pdf)
+* HHS ["Ensuring the Quality of Information Disseminated by HHS agencies"](http://aspe.hhs.gov/infoquality)
 
+All collaborative materials will be controlled by the rules contained within
+this document. This will allow for the real-time collaboration opportunities
+among CDC employees, CDC contractors and CDC public health partners.
 
-## Credit: 
-This code of conduct was mainly adapted from [18F's Code of Conduct](https://github.com/18F/code-of-conduct) and the [CDC's Informatics Innovation Unit R&D Lab's code of conduct.](http://www.phiresearchlab.org/?page_id=1715)
+## Credit
+This code of conduct was mainly adapted from [18F's Code of Conduct](https://github.com/18F/code-of-conduct)
+and the [CDC's Informatics Innovation Unit R&D Lab's code of conduct.](http://www.phiresearchlab.org/?page_id=1715)
 
-##Relevant Legal Considerations: 
-
-[Laws enforced by the Equal Employment Opportunity Commission](http://www.eeoc.gov/laws/statutes/index.cfm) 
-
-[Types of discrimination prohibited by law](http://www.eeoc.gov/laws/types) 
-
-[New and proposed regulations](http://www.eeoc.gov/laws/regulations/index.cfm) 
-
-
-  
-          
-          
+## Relevant Legal Considerations
+* [Laws enforced by the Equal Employment Opportunity Commission](http://www.eeoc.gov/laws/statutes/index.cfm)
+* [Types of discrimination prohibited by law](http://www.eeoc.gov/laws/types)
+* [New and proposed regulations](http://www.eeoc.gov/laws/regulations/index.cfm)


### PR DESCRIPTION
I have formatted the documents to conform to common Markdown conventions, such as limiting line lengths to 80 characters (so they fit in vi with default settings), and placing spaces between hashes and header texts (as @leebrian did with [README.md](https://github.com/CDCgov/template/blob/master/README.md) in #4a43e32b0db0b053db37d394d6ef2c1aa078a5c6).